### PR TITLE
fix: wget in docs has extra index dir

### DIFF
--- a/docs/large_db.md
+++ b/docs/large_db.md
@@ -108,7 +108,7 @@ so you don't need to build it locally.
 You can download it and put in the correct place with
 
 ```bash
-pixi exec wget -c -O bw_k21/index/metadata.parquet \
+pixi exec wget -c -O bw_k21/metadata.parquet \
     https://farm.cse.ucdavis.edu/~irber/branchwater/20241128-metadata.parquet
 ```
 :::


### PR DESCRIPTION
`wget` command has an extra `index/` dir in command