### PR TITLE
mongodb: update metadata_sra task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ pyarrow = "*"
 google-cloud-bigquery = ">=3.28.0,<4"
 
 [tool.pixi.feature.metadata.tasks]
-metadata_sra = { cmd = ["python3", "prepare_sra.py"], cwd = "metadata" }
+metadata_sra = { cmd = ["python3", "prepare_sra.py", "-a", "../bw_db/sraids", "-o", "../bw_db/metadata.parquet"], cwd = "metadata" }
 metadata_bq = { cmd = ["python3", "prepare_bq.py", "-a", "../bw_db/sraids", "-k", "../bw_db/bqKey.json", "-o", "../bw_db/metadata.parquet"], cwd = "metadata" }
 
 [tool.pixi.feature.deploy.tasks]


### PR DESCRIPTION
This is likely just a temporary PR, as mongodb is on its way out. But duckdb isn't working yet

### Old instructions (mongodb)

Instructions modified from `docs/deploy.md` (with Luiz's help) to use non-bigquery SRA loading:

## 1. Install `pixi` if needed: 

```
curl -fsSL https://pixi.sh/install.sh | bash
```
## 2. Install [Rancher Desktop](https://rancherdesktop.io/), [Podman Desktop](https://podman-desktop.io/), or Docker desktop
> Note podman requrires editing the `docker-compose.yml` file to use `podman-compose` instead of `docker compose`

## 3. Download signatures and prepare the index
```
pixi run index -j 4
```

## 4. Get SRA metadata into mongodb for use

First, prep mongodb
```
pixi run deploy up -d mongodb
```

Next, download SRA metadata from parquet via:
```
pixi run metadata_sra
```
> this is the part that changed in this PR

then load it into the mongodb database:
```
pixi run load_mongo
```

## 5. Deploy 
```
 pixi run deploy up -d mongodb
```
> Make sure your docker (via the desktop app) is running first